### PR TITLE
Add channel statistics endpoint and service function

### DIFF
--- a/routes/channelRoutes.js
+++ b/routes/channelRoutes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { getAllUserChannels, deleteChannel } = require('../controllers/userChannelController');
+const { getAllUserChannels, deleteChannel, getChannelStatisticsController } = require('../controllers/userChannelController');
 const { authenticateToken } = require('../middleware/authMiddleware');
 
 // Lấy tất cả channel mà user hiện tại quản lý
@@ -8,5 +8,8 @@ router.get('/', authenticateToken, getAllUserChannels);
 
 // Xoá channel (chỉ owner hoặc admin)
 router.delete('/delete/:channelDbId', authenticateToken, deleteChannel);
+
+// Lấy thống kê 7 ngày của 1 channel cụ thể
+router.get('/:channelDbId/statistics', authenticateToken, getChannelStatisticsController);
 
 module.exports = router; 

--- a/services/userChannelService.js
+++ b/services/userChannelService.js
@@ -78,7 +78,32 @@ const deleteChannelById = async (channelDbId, userId, userRole) => {
   return true;
 };
 
+/**
+ * Lấy thống kê 7 ngày cho 1 channel cụ thể
+ * @param {string} channelDbId
+ * @param {number} days
+ */
+const getChannelStatistics = async (channelDbId, days = 7) => {
+  const stats = await ChannelStatistics.findAll({
+    where: { channel_db_id: channelDbId },
+    order: [['date', 'DESC']],
+    limit: days
+  });
+  
+  return stats.map(row => ({
+    date: row.date,
+    view_count: row.view_count || 0,
+    like_count: row.like_count || 0,
+    subscriber_count: row.subscriber_count || 0,
+    estimated_revenue: row.estimated_revenue || 0,
+    comment_count: row.comment_count || 0,
+    share_count: row.share_count || 0,
+    watch_time_minutes: row.watch_time_minutes || 0
+  })).sort((a, b) => a.date.localeCompare(b.date));
+};
+
 module.exports = {
   getUserChannels,
   deleteChannelById,
+  getChannelStatistics
 }; 


### PR DESCRIPTION
- Implemented `getChannelStatistics` service function to retrieve 7-day statistics for a specific channel.
- Added `getChannelStatisticsController` in `userChannelController` to handle API requests for channel statistics.
- Updated `channelRoutes` to include a new route for fetching channel statistics.
- Included necessary import statements in relevant files.