### PR TITLE
Refactor YouTube history logging to associate logs with user channels

### DIFF
--- a/models/YoutubeHistoryLogs.js
+++ b/models/YoutubeHistoryLogs.js
@@ -7,9 +7,13 @@ const YoutubeHistoryLogs = sequelize.define('YoutubeHistoryLogs', {
     defaultValue: DataTypes.UUIDV4,
     primaryKey: true,
   },
-  channelDbId: {
+  user_channel_id: {
     type: DataTypes.UUID,
     allowNull: false,
+    references: {
+      model: 'user_channel',
+      key: 'id'
+    }
   },
   status: {
     type: DataTypes.ENUM('success', 'failed'),

--- a/models/index.js
+++ b/models/index.js
@@ -75,9 +75,9 @@ UserChannel.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
 YouTubeChannel.hasMany(UserChannel, { foreignKey: 'channel_db_id', as: 'user_channels' });
 UserChannel.belongsTo(YouTubeChannel, { foreignKey: 'channel_db_id', as: 'youtube_channel' });
 
-// YoutubeHistoryLogs belongsTo YouTubeChannel
-YoutubeHistoryLogs.belongsTo(YouTubeChannel, { foreignKey: 'channelDbId', as: 'youtube_channel' });
-YouTubeChannel.hasMany(YoutubeHistoryLogs, { foreignKey: 'channelDbId', as: 'youtube_history_logs' });
+// YoutubeHistoryLogs belongsTo UserChannel
+YoutubeHistoryLogs.belongsTo(UserChannel, { foreignKey: 'user_channel_id', as: 'user_channel' });
+UserChannel.hasMany(YoutubeHistoryLogs, { foreignKey: 'user_channel_id', as: 'youtube_history_logs' });
 
 module.exports = {
   User,

--- a/services/youtubeSyncService.js
+++ b/services/youtubeSyncService.js
@@ -387,9 +387,15 @@ async function syncYouTubeChannelData({
     result = analyticsError || "Sync failed for unknown reason";
   }
 
+  // Tìm user_channel
+  const userChannel = await UserChannel.findOne({
+    where: { user_id: userId, channel_db_id: channelDbId, is_active: true }
+  });
+  if (!userChannel) throw new Error('User does not have permission for this channel');
+
   // Ghi log lịch sử đồng bộ
   await YoutubeHistoryLogs.create({
-    channelDbId,
+    user_channel_id: userChannel.id,
     status: !analyticsError ? 'success' : 'failed',
     result, // result giờ chỉ là string
     list_video_new,


### PR DESCRIPTION
- Updated `syncHistoryController` to retrieve user channel IDs instead of channel database IDs for fetching history logs.
- Modified `YoutubeHistoryLogs` model to reference `user_channel_id` instead of `channelDbId`.
- Enhanced permission checks in `getChannelHistoryLogs` and `syncYouTubeChannelData` to ensure users can only access their own channel history.
- Updated associations in the models to reflect the new relationship between `YoutubeHistoryLogs` and `UserChannel`.